### PR TITLE
No longer saves the password

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ npm-debug.*
 *.mobileprovision
 *.orig.*
 web-build/
+.idea/
 
 # macOS
 .DS_Store

--- a/backend/src/authentication.ts
+++ b/backend/src/authentication.ts
@@ -19,7 +19,6 @@ const registerUser = async (
       created_at: Timestamp.now(),
       birthdate: birthdate,
       name: name,
-      passphrase: password,
       phonenumber: phonenumber,
       children: [],
       profilePicture: "https://firebasestorage.googleapis.com/v0/b/mobile-banking-app-dacb3.appspot.com/o/Profile%20Pictures%2FDefault_pfp.png?alt=media&token=3c5ea107-33ee-4b7b-8df6-4ab8b3522aaa"
@@ -49,7 +48,6 @@ const registerChild = async (
       created_at: Timestamp.now(),
       birthdate: birthdate,
       name: name,
-      passphrase: password,
       phonenumber: phonenumber,
       children: [],
       parents: [parentUid],

--- a/backend/types/user.ts
+++ b/backend/types/user.ts
@@ -9,7 +9,6 @@ const UserSchema = z.object({
     created_at: FirestoreTimestampSchema,
     birthdate: FirestoreTimestampSchema,
     name: z.string(),
-    passphrase: z.string(),
     phonenumber: z.number(),
     children: z.array(z.string()).optional(),
     parents: z.array(z.string()).optional(),


### PR DESCRIPTION
### Pull Request Summary

Firebase's authentication stores the password with salt, so we should not save it in plaintext ourselves. 

---

### Description of Changes

Removes passphrase from the schema, as well as in the implementations

---

### Related Issues

closes #59 
---

### Testing & Validation

No testing done. Should probably, but very small issue.
---

### Additional Notes


---
